### PR TITLE
enable gdb server by default

### DIFF
--- a/.config-r36a-knx-router
+++ b/.config-r36a-knx-router
@@ -2015,7 +2015,7 @@ CONFIG_ZABBIX_POSTGRESQL=y
 # CONFIG_PACKAGE_diffutils is not set
 # CONFIG_PACKAGE_gcc is not set
 # CONFIG_PACKAGE_gdb is not set
-CONFIG_PACKAGE_gdbserver=m
+CONFIG_PACKAGE_gdbserver=y
 # CONFIG_PACKAGE_gitlab-runner is not set
 # CONFIG_PACKAGE_libtool-bin is not set
 # CONFIG_PACKAGE_lpc21isp is not set

--- a/.config-r36a-linker
+++ b/.config-r36a-linker
@@ -2023,7 +2023,7 @@ CONFIG_ZABBIX_POSTGRESQL=y
 # CONFIG_PACKAGE_diffutils is not set
 # CONFIG_PACKAGE_gcc is not set
 # CONFIG_PACKAGE_gdb is not set
-CONFIG_PACKAGE_gdbserver=m
+CONFIG_PACKAGE_gdbserver=y
 # CONFIG_PACKAGE_gitlab-runner is not set
 # CONFIG_PACKAGE_libtool-bin is not set
 # CONFIG_PACKAGE_lpc21isp is not set


### PR DESCRIPTION
Normally I like to install gdbserver separately, but recently there has not been enough room in the Flash for that, if installed as a separate package. This pull requests enables the GDB server to be installed by default in the squashFS image, which takes up a bit less room.