### PR TITLE
knxiotubus: Update readme to include new UBUS library

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ repositories. Unfortunately relative paths do not work.
 - knxiotlinker - Cascoda's proprietary KNX-IoT development tool which links points
   together based on their functional blocks (smart linking).
 - knxiotproxy - Cascoda's propretary proxy from KNX-IoT to MQTT.
+- knxiotubus - Cascoda's proprietary KNX-IoT backend and frontend to allow 
+  configuring virtual devices on the border router using a web gui.
 
 Note: Cascoda's logo is displayed in the header through a modification to the bootstrap
 theme, in `luci-theme-bootstrap/luasrc/view/themes/bootstrap/header.htm`. This is not


### PR DESCRIPTION
Added basic readme info on the ubus library so it can be known that it is required.
The feed is still missing in feeds.conf(.default) so needs to be added there, potentially the package also needs to be included in the .config but it maybe that it gets pulled in automatically as a dependency.
