### PR TITLE
Fixes for IoT router

### DIFF
--- a/.config-r36a-knx-router
+++ b/.config-r36a-knx-router
@@ -3464,7 +3464,7 @@ CONFIG_PACKAGE_python3-sqlite3=y
 # CONFIG_PACKAGE_python3-toml is not set
 # CONFIG_PACKAGE_python3-tornado is not set
 # CONFIG_PACKAGE_python3-twisted is not set
-# CONFIG_PACKAGE_python3-typing-extensions is not set
+CONFIG_PACKAGE_python3-typing-extensions=y
 # CONFIG_PACKAGE_python3-ubus is not set
 # CONFIG_PACKAGE_python3-uci is not set
 CONFIG_PACKAGE_python3-unidecode=y
@@ -4217,7 +4217,7 @@ CONFIG_PACKAGE_jansson=y
 # CONFIG_PACKAGE_knot-libs is not set
 # CONFIG_PACKAGE_knot-libzscanner is not set
 # CONFIG_PACKAGE_knx-iot-br-config is not set
-CONFIG_PACKAGE_knx-iot-mqtt=y
+# CONFIG_PACKAGE_knx-iot-mqtt is not set
 # CONFIG_PACKAGE_knx_certification is not set
 # CONFIG_PACKAGE_libaio is not set
 # CONFIG_PACKAGE_libantlr3c is not set

--- a/build.sh
+++ b/build.sh
@@ -2,5 +2,7 @@
 ./scripts/feeds update -a
 ./scripts/feeds install -a
 make clean
-make
+make -j12
+#More logs to file, for debugging
+#make -j12 V=sc -k 2>&1 | tee build_log.txt 
 cmatrix -b

--- a/feeds.conf.default
+++ b/feeds.conf.default
@@ -1,4 +1,4 @@
-src-git-full packages https://git.openwrt.org/feed/packages.git^426ccd2e0cf56394017d32b864cd66a570852706
+src-git-full packages https://github.com/Cascoda/packages;openwrt-22.03
 src-git-full luci https://git.openwrt.org/project/luci.git^487e58a0a61f8d2396893bd9fa6695269b1fd1d3
 src-git-full routing https://git.openwrt.org/feed/routing.git^8872359011eee64981804f7ed42d5d6b54add6d8
 src-git-full telephony https://git.openwrt.org/feed/telephony.git^1d2031a5c82816483c51bca15649e2957fbe2bc2


### PR DESCRIPTION
1. Enable typing_extensions package, which is required by the router
2. Disable mqtt proxy when the router is built
3. Switch from openwrt/packages to Cascoda/packages, which has fixes for typing_extension
4. Update build shell script